### PR TITLE
Fix: avoid MacOS runner error

### DIFF
--- a/.github/workflows/logsFromNative-Example-CI.yml
+++ b/.github/workflows/logsFromNative-Example-CI.yml
@@ -138,5 +138,12 @@ jobs:
       - name: Install pod dependencies
         run: cd example/ios && pod install --verbose
 
+      - name: Opening Simulator app
+        run: |
+          while ! open -Fn /Applications/Xcode_13.2.1.app/Contents/Developer/Applications/Simulator.app; do
+            echo "Retry"
+          done
+          echo "Success"
+
       - name: Builds the iOS app
         run: cd example && npx react-native run-ios


### PR DESCRIPTION
There's an issue with the macos-latest runner which is that the device (iPhone simulator) is not ready or cannot be opened before building the example application.
This causes the Example workflow to randomly fail and randomly pass.

To avoid this error new step has been introduced which will retry on opening the device until it is ready and available and will pass only when the device is ready for further build step.
